### PR TITLE
Turn the "authors" list into a list of objects

### DIFF
--- a/content/2020-12/_index.markdown
+++ b/content/2020-12/_index.markdown
@@ -2,6 +2,10 @@
 title: "2020-12"
 summary: "JSON Schema 2020-12 is a JSON media type for defining the structure of JSON data. JSON Schema is intended to define validation, documentation, hyperlink navigation, and interaction control of JSON data."
 specification: "https://json-schema.org/draft/2020-12/json-schema-core.html"
-authors: [ "awwright", "handrews", "relequestual", "gregsdennis" ]
+authors:
+  - github: awwright
+  - github: handrews
+  - github: relequestual
+  - github: gregsdennis
 metaschema: "https://json-schema.org/draft/2020-12/schema"
 ---

--- a/content/2020-12/applicator/_index.markdown
+++ b/content/2020-12/applicator/_index.markdown
@@ -2,7 +2,11 @@
 title: "Applicator"
 summary: "A vocabulary that defines applicator keywords that are recommended for use as the basis of other vocabularies."
 specification: "https://json-schema.org/draft/2020-12/json-schema-core.html#section-10"
-authors: [ "awwright", "handrews", "relequestual", "gregsdennis" ]
+authors:
+  - github: awwright
+  - github: handrews
+  - github: relequestual
+  - github: gregsdennis
 uri: "https://json-schema.org/draft/2020-12/vocab/applicator"
 metaschema: "https://json-schema.org/draft/2020-12/meta/applicator"
 official: true

--- a/content/2020-12/content/_index.markdown
+++ b/content/2020-12/content/_index.markdown
@@ -2,7 +2,10 @@
 title: "Content"
 summary: "A vocabulary that defines keywords for annotating instances that contain non-JSON data encoded in JSON strings."
 specification: "https://json-schema.org/draft/2020-12/json-schema-validation.html#section-8"
-authors: [ "awwright", "handrews", "relequestual" ]
+authors:
+  - github: awwright
+  - github: handrews
+  - github: relequestual
 uri: "https://json-schema.org/draft/2020-12/vocab/content"
 metaschema: "https://json-schema.org/draft/2020-12/meta/content"
 official: true

--- a/content/2020-12/core/_index.markdown
+++ b/content/2020-12/core/_index.markdown
@@ -2,7 +2,11 @@
 title: "Core"
 summary: "A mandatory vocabulary that defines keywords that are either required in order to process any schema or meta-schema, including those split across multiple documents, or exist to reserve keywords for purposes that require guaranteed interoperability."
 specification: "https://json-schema.org/draft/2020-12/json-schema-core.html#section-8"
-authors: [ "awwright", "handrews", "relequestual", "gregsdennis" ]
+authors:
+  - github: awwright
+  - github: handrews
+  - github: relequestual
+  - github: gregsdennis
 uri: "https://json-schema.org/draft/2020-12/vocab/core"
 metaschema: "https://json-schema.org/draft/2020-12/meta/core"
 official: true

--- a/content/2020-12/format-annotation/_index.markdown
+++ b/content/2020-12/format-annotation/_index.markdown
@@ -2,7 +2,10 @@
 title: "Format Annotation"
 summary: "A vocabulary to defines semantic information about string-encoded values."
 specification: "https://json-schema.org/draft/2020-12/json-schema-validation.html#section-7.2.1"
-authors: [ "awwright", "handrews", "relequestual" ]
+authors:
+  - github: awwright
+  - github: handrews
+  - github: relequestual
 uri: "https://json-schema.org/draft/2020-12/vocab/format-annotation"
 metaschema: "https://json-schema.org/draft/2020-12/meta/format-annotation"
 official: true

--- a/content/2020-12/format-assertion/_index.markdown
+++ b/content/2020-12/format-assertion/_index.markdown
@@ -2,7 +2,10 @@
 title: "Format Assertion"
 summary: "A vocabulary to defines and asserts semantic information about string-encoded values."
 specification: "https://json-schema.org/draft/2020-12/json-schema-validation.html#section-7.2.2"
-authors: [ "awwright", "handrews", "relequestual" ]
+authors:
+  - github: awwright
+  - github: handrews
+  - github: relequestual
 uri: "https://json-schema.org/draft/2020-12/vocab/format-assertion"
 metaschema: "https://json-schema.org/draft/2020-12/meta/format-assertion"
 official: true

--- a/content/2020-12/meta-data/_index.markdown
+++ b/content/2020-12/meta-data/_index.markdown
@@ -2,7 +2,10 @@
 title: "Meta Data"
 summary: "A vocabulary to defines general-purpose annotation keywords that provide commonly used information for documentation and user interface display purposes."
 specification: "https://json-schema.org/draft/2020-12/json-schema-validation.html#section-9"
-authors: [ "awwright", "handrews", "relequestual" ]
+authors:
+  - github: awwright
+  - github: handrews
+  - github: relequestual
 uri: "https://json-schema.org/draft/2020-12/vocab/meta-data"
 metaschema: "https://json-schema.org/draft/2020-12/meta/meta-data"
 official: true

--- a/content/2020-12/unevaluated/_index.markdown
+++ b/content/2020-12/unevaluated/_index.markdown
@@ -2,7 +2,11 @@
 title: "Unevaluated"
 summary: "A mandatory vocabulary that defines keywords that apply subschemas to array items or object properties that have not been successfully evaluated against any dynamic-scope subschema of any adjacent keywords."
 specification: "https://json-schema.org/draft/2020-12/json-schema-core.html#section-11"
-authors: [ "awwright", "handrews", "relequestual", "gregsdennis" ]
+authors:
+  - github: awwright
+  - github: handrews
+  - github: relequestual
+  - github: gregsdennis
 uri: "https://json-schema.org/draft/2020-12/vocab/unevaluated"
 metaschema: "https://json-schema.org/draft/2020-12/meta/unevaluated"
 official: true

--- a/content/2020-12/validation/_index.markdown
+++ b/content/2020-12/validation/_index.markdown
@@ -2,7 +2,10 @@
 title: "Validation"
 summary: "A vocabulary that defines keywords that impose requirements for successful validation of an instance."
 specification: "https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6"
-authors: [ "awwright", "handrews", "relequestual" ]
+authors:
+  - github: awwright
+  - github: handrews
+  - github: relequestual
 uri: "https://json-schema.org/draft/2020-12/vocab/validation"
 metaschema: "https://json-schema.org/draft/2020-12/meta/validation"
 official: true

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -76,9 +76,9 @@
                 <ul class="mb-0 ps-0 font-monospace list-unstyled">
                   {{ range (.Params.authors) }}
                     <li class="my-1">
-                      <a target="_blank" href="https://github.com/{{ . }}">
-                        <img class="rounded" src="https://github.com/{{ . }}.png?size=60" width="30" height="30">
-                        @{{ . }}
+                      <a target="_blank" href="https://github.com/{{ .github }}">
+                        <img class="rounded" src="https://github.com/{{ .github }}.png?size=60" width="30" height="30">
+                        @{{ .github }}
                       </a>
                     </li>
                   {{ end }}


### PR DESCRIPTION
So that we can eventually add more metadata for other purposes, like
citations.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
