### PR TITLE
Add flex to body and fill the main content

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -41,7 +41,7 @@
       }
     </script>
   </head>
-  <body class="h-100 bg-light">
+  <body class="h-100 bg-light d-flex flex-column">
     {{ partial "navigation.html" . }}
 
     {{ block "main" . }}

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -19,7 +19,7 @@
     "githubURL" $githubURL ) }}
 {{ end }}
 
-<div class="d-flex bg-body">
+<div class="d-flex bg-body flex-fill">
   {{ partial "sidebar.html" . }}
   <div class="flex-xl-grow-1 mw-100">
     <main class="px-3 px-lg-5 pt-4 pb-3">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
   "keyword" .Params.keyword
   "githubURL" $githubURL ) }}
 
-<div class="d-flex bg-body">
+<div class="d-flex bg-body flex-fill">
   {{ partial "sidebar.html" . }}
   <div class="flex-xl-grow-1 mw-100">
     <main class="px-3 px-lg-5 pt-4 pb-3">


### PR DESCRIPTION
Hey I found this website today and think it's a great reference!
I noticed that when the main content doesn't fill the page vertically, then the footer takes more space than needed.

I added display flex to the body and flex filled the main content. This expands the main content to fill the empty space and collapses the footer to minimum height.


Here's a before and after of the change:
**before**:
![before](https://user-images.githubusercontent.com/1645882/233197679-9486b244-b295-40ee-b899-dec7fbf36235.png)
![after](https://user-images.githubusercontent.com/1645882/233197676-356157b8-6cb0-45ec-ba87-69205f44b161.png)