### PR TITLE
Adds integer type

### DIFF
--- a/content/2020-12/validation/type.markdown
+++ b/content/2020-12/validation/type.markdown
@@ -17,3 +17,4 @@ The supported types are:
 - `"array"`
 - `"number"`
 - `"string"`
+- `"integer"`  


### PR DESCRIPTION
According to the link, https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.1.1-2, in this markdown document, `"integer"` is also a valid type. 

It says:

> String values MUST be one of the six primitive types ("null", "boolean", "object", "array", "number", or "string"), or "integer" which matches any number with a zero fractional part.