### PR TITLE
Fix typo in `const` description

### DIFF
--- a/content/2020-12/validation/const.markdown
+++ b/content/2020-12/validation/const.markdown
@@ -1,7 +1,7 @@
 ---
 keyword: "const"
 signature: "Any"
-summary: "Validation succeeds if the instance is equal this keyword's value."
+summary: "Validation succeeds if the instance is equal to this keyword's value."
 kind: [ "assertion" ]
 instance: [ "any" ]
 specification: "https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.1.3"


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
