### PR TITLE
Fix grammar of `minContains` and `maxContains` descriptions

### DIFF
--- a/content/2020-12/validation/maxContains.markdown
+++ b/content/2020-12/validation/maxContains.markdown
@@ -1,7 +1,7 @@
 ---
 keyword: "maxContains"
 signature: "Integer"
-summary: "The number of times that the `contains` keyword (if set) successfully validates against the instance must be less than or equal to given integer."
+summary: "The number of times that the `contains` keyword (if set) successfully validates against the instance must be less than or equal to the given integer."
 kind: [ "assertion" ]
 instance: [ "array" ]
 specification: "https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.4"

--- a/content/2020-12/validation/minContains.markdown
+++ b/content/2020-12/validation/minContains.markdown
@@ -1,7 +1,7 @@
 ---
 keyword: "minContains"
 signature: "Integer"
-summary: "The number of times that the `contains` keyword (if set) successfully validates against the instance must be greater than or equal to given integer."
+summary: "The number of times that the `contains` keyword (if set) successfully validates against the instance must be greater than or equal to the given integer."
 kind: [ "assertion" ]
 instance: [ "array" ]
 specification: "https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.5"


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
