### PR TITLE
Truly redirect / to /2020-12

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,3 +1,9 @@
-{{ with .GetPage "/2020-12" }}
-  {{ .Render }}
-{{ end }}
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}" class="h-100">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/2020-12" />
+</head>
+<body>
+  <p>Redirecting to <a href="/2020-12">/2020-12</a>. If you are not redirected automatically, <a href="/2020-12">click here</a>.</p>
+</body>


### PR DESCRIPTION
The current approach doesn't seem to work on latest Hugo anymore.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
