### PR TITLE
Fix `pagination` Hugo deprecation warning

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,7 +1,9 @@
 languageCode = 'en-us'
 title = 'Reference documentation for JSON Schema'
 staticDir = [ './vendor/bootstrap-icons/font/fonts', './static' ]
-paginate = 100000000
+
+[pagination]
+pagerSize = 100000000
 
 [Params]
 description = 'Reference documentation for JSON Schema'


### PR DESCRIPTION
```
ERROR deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.143.0. Use pagination.pagerSize instead.
```

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
