### PR TITLE
Chore/devcontainer-config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "hugo extended install for learnjsonschema.com",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/hugo:1": {
+      "version": "latest",
+      "extended": true
+    },
+    "ghcr.io/devcontainers/features/node": {
+      "version": "lts",
+      "installNpm": true
+    }
+  },
+  "forwardPorts": [
+    1313
+  ],
+  "postCreateCommand": "npm i"
+}


### PR DESCRIPTION
This adds a codespace devcontainer configuration to make sure the Hugo Extended version is installed for all environments. 

I found using Win 10, the incorrect Hugo version is installed when using a GH Codespace, which doesn't allow for the use of the `make` command to build the docs locally without an error related to SASS

```
TOCSS: failed to transform "/main.scss"
```

This should provide more consistency for contributors. 

_ref: https://stackoverflow.com/a/55957784/8564731_